### PR TITLE
Changing logic as pre-inc is valid and equations are not

### DIFF
--- a/lib/rules/no-overwritten-increment.js
+++ b/lib/rules/no-overwritten-increment.js
@@ -26,6 +26,7 @@ module.exports = {
     create: function(context) {
 
         // variables should be defined here
+        var assignmentStack = [];
 
         //----------------------------------------------------------------------
         // Helpers
@@ -33,20 +34,43 @@ module.exports = {
 
         // any helper functions should go here or else delete this section
 
-        function checkAssignmentExpression(node) {
-            if (node.right.type !== "UpdateExpression") {
+        function isBeingAssigned(node) {
+            var length = assignmentStack.length;
+            var i;
+
+            // iterate backwards, to search the nearest ancestor first
+            for (i = 0; i < length; i++) {
+                if (areExpressionsEquivalent(node, assignmentStack[i].left)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        function checkUpdateExpression(node) {
+            // pre-inc and pre-dec are not affected, only post-inc/dec
+            if (node.prefix) {
                 return;
             }
 
-            if (areExpressionsEquivalent(node.left, node.right.argument)) {
+            if (isBeingAssigned(node.argument)) {
                 context.report({
                     node: node,
                     message: "Should not combine an assignment with the {{direction}} of the left hand side. The original value would immediately overwrite the {{direction}}ed value.",
                     data: {
-                        direction: node.right.operator === '++' ? 'increment' : 'decrement'
+                        direction: node.operator === '++' ? 'increment' : 'decrement'
                     }
                 });
             }
+        }
+
+        function enterAssignment(node) {
+            assignmentStack.push(node);
+        }
+
+        function exitAssignment(node) {
+            assignmentStack.pop();
         }
 
         //----------------------------------------------------------------------
@@ -54,7 +78,10 @@ module.exports = {
         //----------------------------------------------------------------------
 
         return {
-            "AssignmentExpression": checkAssignmentExpression
+            "UpdateExpression": checkUpdateExpression,
+
+            "AssignmentExpression": enterAssignment,
+            "AssignmentExpression:exit": exitAssignment
         };
     }
 };

--- a/tests/lib/rules/no-overwritten-increment.js
+++ b/tests/lib/rules/no-overwritten-increment.js
@@ -23,7 +23,7 @@ ruleTester.run("no-overwritten-increment", rule, {
     valid: [
         "x = y",
         "x = y++",
-        "x = x++ + 1;"
+        "x = ++x"
     ],
 
     invalid: [
@@ -31,15 +31,15 @@ ruleTester.run("no-overwritten-increment", rule, {
             code: "x = x++;",
             errors: [{
                 message: "Should not combine an assignment with the increment of the left hand side. The original value would immediately overwrite the incremented value.",
-                type: "AssignmentExpression"
+                type: "UpdateExpression"
             }]
         },
 
         {
-            code: "x = (--x);",
+            code: "x[0] = (x[0]--) + 1;",
             errors: [{
                 message: "Should not combine an assignment with the decrement of the left hand side. The original value would immediately overwrite the decremented value.",
-                type: "AssignmentExpression"
+                type: "UpdateExpression"
             }]
         }
     ]


### PR DESCRIPTION
Originally, prevented pre-increment and pre-decrement. These two turn out to not be affected by the overwrite update issue. The original also permitted equations such as `x = x++ + 1;` which do still exhibit the overwritten update issue.